### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ jscs: node_modules/jscs/bin/jscs
 	./node_modules/jscs/bin/jscs media/js/main.js media/js/models/ media/js/collections/ media/js/views/ media/js/utils/
 
 node_modules/jshint/bin/jshint:
-	npm install jshint
+	npm install jshint --prefix .
 
 node_modules/jscs/bin/jscs:
-	npm install jscs
+	npm install jscs --prefix .
 
 test: ./ve/bin/python
 	$(MANAGE) jenkins
@@ -41,8 +41,8 @@ clean:
 	rm -rf ve
 	rm -rf media/CACHE
 	rm -rf reports
-	rm celerybeat-schedule
-	rm .coverage
+	rm -f celerybeat-schedule
+	rm -f .coverage
 	find . -name '*.pyc' -exec rm {} \;
 
 pull:


### PR DESCRIPTION
There's two changes here:
- Force npm packages to get installed in the current directory. I had
  jshint installed in ~/node_modules, so `npm install jshint` didn't
  do anything, and `./node_modules/jshint/bin/jshint` didn't exist.
- Force delete any files deleted on `make clean`, to ignore errors
  thrown when these files don't exist.
