### PR TITLE
Change wording in stage save button from 'edit' to 'Save'

### DIFF
--- a/rolf/templates/rolf/stage_detail.html
+++ b/rolf/templates/rolf/stage_detail.html
@@ -50,7 +50,7 @@ Or edit code:<br />
 <textarea name="code" cols="60" rows="10" class="input-block-level">{{object.recipe.code}}</textarea>
 
 </td>{% endif %}</tr>
-</table><input type="submit" value="edit" />
+</table><input type="submit" value="Save" />
 
 </form>
 


### PR DESCRIPTION
The 'edit' button was confusing, since what it really does is save the
form.
