### PR TITLE
Fix status text going outside of the status box

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -146,9 +146,8 @@ td.stderr pre {
 }
 
 div#push-status {
-
-		font-size: 300%;
-
+    font-size: 300%;
+    line-height: 100%;
 }
 
 div.ok {


### PR DESCRIPTION
![screenshot from 2014-12-05 10 48 40](https://cloud.githubusercontent.com/assets/59292/5318235/4b622130-7c6c-11e4-97cf-d483ad490c74.png)
->
![screenshot from 2014-12-05 10 48 32](https://cloud.githubusercontent.com/assets/59292/5318237/4e3100b6-7c6c-11e4-9523-b14cbc25921a.png)
