### PR TITLE
Remove duplicate jquery 1.4.2

### DIFF
--- a/rolf/templates/rolf/deployment_detail.html
+++ b/rolf/templates/rolf/deployment_detail.html
@@ -5,8 +5,6 @@
 {% block js %}
 
 <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/themes/base/jquery-ui.css" type="text/css" media="all" /> 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"
-        type="text/javascript" ></script>
 <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/jquery-ui.min.js" type="text/javascript"></script>
 
 

--- a/rolf/templates/rolf/index.html
+++ b/rolf/templates/rolf/index.html
@@ -2,8 +2,6 @@
 
 {% block js %}
 <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/themes/base/jquery-ui.css" type="text/css" media="all" /> 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"
-        type="text/javascript" ></script>
 <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/jquery-ui.min.js" type="text/javascript"></script>
 {% endblock %}
 

--- a/rolf/templates/rolf/recipe_detail.html
+++ b/rolf/templates/rolf/recipe_detail.html
@@ -2,8 +2,6 @@
 {% load perms %}
 {% block js %}
 <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/themes/base/jquery-ui.css" type="text/css" media="all" /> 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"
-        type="text/javascript" ></script>
 <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/jquery-ui.min.js" type="text/javascript"></script>
 {% endblock %}
 

--- a/rolf/templates/stats.html
+++ b/rolf/templates/stats.html
@@ -2,7 +2,6 @@
 
 {% block js %}
 <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/themes/base/jquery-ui.css" type="text/css" media="all" /> 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript" ></script>
 <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.3/jquery-ui.min.js" type="text/javascript"></script>
 {% endblock %}
 


### PR DESCRIPTION
On each of the pages that's including jquery 1.4.2,
jquery 1.7.2 is already included as part of base.html
which seems to be working fine with the specified
version of jquery-ui.