### PR TITLE
Remove raven.contrib.django from INSTALLED_APPS

### DIFF
--- a/rolf/settings_shared.py
+++ b/rolf/settings_shared.py
@@ -94,7 +94,6 @@ INSTALLED_APPS = [
     'django_extensions',
     'rolf.rolf_main',
     'django_statsd',
-    'raven.contrib.django',
     'smoketest',
     'debug_toolbar',
     'django_jenkins',


### PR DESCRIPTION
To fix this error:
> ImproperlyConfigured: Application labels aren't unique, duplicates: raven.contrib.django