### PR TITLE
remove js tests from jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MANAGE=./manage.py
 APP=rolf
 FLAKE8=./ve/bin/flake8
 
-jenkins: ./ve/bin/python check jshint jscs flake8 test
+jenkins: ./ve/bin/python check flake8 test
 
 ./ve/bin/python: requirements.txt bootstrap.py virtualenv.py
 	./bootstrap.py


### PR DESCRIPTION
these aren't reliable on jasper, which has a very old nodejs/npm.