### PR TITLE
add django-cacheds3storage==0.1.1 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,5 +43,5 @@ django-waffle==0.10.1
 django-appconf==1.0.1
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0
-
+django-cacheds3storage==0.1.1
 ccnmtlsettings==0.1.0


### PR DESCRIPTION
Resolve 500 error on production

ImportError at /admin/
No module named cacheds3storage