### PR TITLE
explicitly disable s3static

### DIFF
--- a/rolf/settings_production.py
+++ b/rolf/settings_production.py
@@ -8,6 +8,7 @@ locals().update(
         base=base,
         INSTALLED_APPS=INSTALLED_APPS,
         STATIC_ROOT=STATIC_ROOT,
+        s3static=False,
     )
 )
 


### PR DESCRIPTION
fix the admin 500 errors.

forgot that ccnmtlsettings defaults to doing s3 static stuff. you have to
explicitly turn it off for older apps that aren't set up for s3 yet