### PR TITLE
automatically clear out old pushes

### DIFF
--- a/rolf/rolf_main/management/commands/delete_old_logs.py
+++ b/rolf/rolf_main/management/commands/delete_old_logs.py
@@ -11,12 +11,6 @@ class Command(BaseCommand):
         deleted = 0
         for deployment in Deployment.objects.all():
             print("[%02d/%02d]" % (idx, count))
-            if deployment.push_set.all().count() < KEEP:
-                # skip any that have 0 or 1 pushes
-                continue
-            for push in list(deployment.push_set.all().order_by(
-                    '-start_time'))[KEEP:]:
-                push.delete()
-                deleted += 1
+            deleted += deployment.clear_old_pushes(keep=KEEP)
             idx += 1
         print("deleted %d" % deleted)

--- a/rolf/rolf_main/models.py
+++ b/rolf/rolf_main/models.py
@@ -184,8 +184,8 @@ class Deployment(models.Model):
         deleted = 0
         if self.push_set.all().count() < keep:
             return deleted
-        for push in list(self.push_set.all().order_by(
-                '-start_time'))[keep:]:
+        for push in self.push_set.all().order_by(
+                '-start_time')[keep:]:
             push.delete()
             deleted += 1
         return deleted

--- a/rolf/rolf_main/models.py
+++ b/rolf/rolf_main/models.py
@@ -180,6 +180,16 @@ class Deployment(models.Model):
                                 default=flag.default,
                                 description=flag.description)
 
+    def clear_old_pushes(self, keep=20):
+        deleted = 0
+        if self.push_set.all().count() < keep:
+            return deleted
+        for push in list(self.push_set.all().order_by(
+                '-start_time'))[keep:]:
+            push.delete()
+            deleted += 1
+        return deleted
+
 
 class Permission(models.Model):
     deployment = models.ForeignKey(Deployment)
@@ -258,6 +268,10 @@ class Push(models.Model):
             self.status = pushstage.status
             self.end_time = datetime.now()
             self.save()
+            if pushstage.status != "failed":
+                # on a successful push, the deployment should
+                # clear out old pushes
+                self.deployment.clear_old_pushes()
         return pushstage
 
     def checkout_dir(self):

--- a/rolf/rolf_main/tests/factories.py
+++ b/rolf/rolf_main/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 from django.contrib.auth.models import User
 from rolf.rolf_main.models import Category, Application, Deployment
-from rolf.rolf_main.models import Recipe, Setting, Stage
+from rolf.rolf_main.models import Recipe, Setting, Stage, Push
 
 
 class CategoryFactory(factory.DjangoModelFactory):
@@ -27,7 +27,7 @@ class DeploymentFactory(factory.DjangoModelFactory):
 class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = User
-    username = 'testuser'
+    username = factory.Sequence(lambda n: 'testuser{0}'.format(n))
 
 
 class RecipeFactory(factory.DjangoModelFactory):
@@ -59,3 +59,10 @@ class StageFactory(factory.DjangoModelFactory):
     name = "test stage"
     deployment = factory.SubFactory(DeploymentFactory)
     recipe = factory.SubFactory(RecipeFactory)
+
+
+class PushFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Push
+    user = factory.SubFactory(UserFactory)
+    deployment = factory.SubFactory(DeploymentFactory)

--- a/rolf/rolf_main/tests/test_model.py
+++ b/rolf/rolf_main/tests/test_model.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from factories import CategoryFactory, ApplicationFactory, DeploymentFactory
 from factories import UserFactory, RecipeFactory, ShellRecipeFactory
-from factories import SettingFactory, StageFactory
+from factories import SettingFactory, StageFactory, PushFactory
 
 
 class CategoryTest(TestCase):
@@ -87,6 +87,20 @@ class DeploymentTest(TestCase):
         d2 = DeploymentFactory()
         d1.clone_stages(d2)
         self.assertTrue(d2.stage_set.all().count() > 0)
+
+    def test_clear_old_pushes_below_threshold(self):
+        p = PushFactory()
+        d = p.deployment
+        d.clear_old_pushes(keep=2)
+        self.assertEqual(d.push_set.count(), 1)
+
+    def test_clear_old_pushes_over_threshold(self):
+        d = DeploymentFactory()
+        PushFactory(deployment=d)
+        PushFactory(deployment=d)
+        PushFactory(deployment=d)
+        d.clear_old_pushes(keep=2)
+        self.assertEqual(d.push_set.count(), 2)
 
 
 class BasicPushTest(TestCase):


### PR DESCRIPTION
To keep the database from growing to 14GB again, whenever a push
completes successfully, we now automatically delete old pushes for the
deployment. Current default is to keep the 20 most recent pushes.