### PR TITLE
avoid testing directory conflict

### DIFF
--- a/rolf/rolf_main/tests/test_model.py
+++ b/rolf/rolf_main/tests/test_model.py
@@ -1,3 +1,6 @@
+import shutil
+import tempfile
+
 from django.test import TestCase
 from factories import CategoryFactory, ApplicationFactory, DeploymentFactory
 from factories import UserFactory, RecipeFactory, ShellRecipeFactory
@@ -121,8 +124,11 @@ class BasicPushTest(TestCase):
         push = self.d.new_push(self.u, "test push")
         # haven't run anything so it should be inprogress
         self.assertEquals(push.status, "inprogress")
-        for s in self.d.stage_set.all():
-            push.run_stage(s.id)
+        tempdir = tempfile.mkdtemp()
+        with self.settings(SCRIPT_DIR=tempdir):
+            for s in self.d.stage_set.all():
+                push.run_stage(s.id)
+        shutil.rmtree(tempdir)
         # should have completed successfully
         self.assertEquals(push.status, "ok")
         # and let's make sure a setting variable has round-tripped


### PR DESCRIPTION
Running the unit tests on a machine where a different user had run the
unit tests previously caused a conflict because they both expected to be
able to use (and own) `/tmp/scripts`.

This change uses `tempfile.mkdtemp()` to properly generate a new test
directory for every run, which should avoid the problem.