### PR TITLE
get jshint/jscs running inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
 FROM ccnmtl/django.base
-RUN apt-get update && apt-get install -y curl git-core python3-requests
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+		git-core \
+		python3-requests \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
 ADD ssh_config /etc/ssh/ssh_config
+COPY package.json /node/
+RUN cd /node && npm install && touch /node/node_modules/sentinal
 ADD wheelhouse /wheelhouse
-RUN /ve/bin/pip install --no-index -f /wheelhouse -r /wheelhouse/requirements.txt
+RUN /ve/bin/pip install --no-index -f /wheelhouse -r /wheelhouse/requirements.txt && touch /ve/sentinal
 WORKDIR /app
 COPY . /app/
-RUN mkdir -p /var/www/rolf/rolf
-RUN mkdir -p /var/tmp/rolf/checkouts
-RUN mkdir -p /var/tmp/rolf/scripts
-RUN /ve/bin/flake8 /app/rolf/ --max-complexity=10
-RUN /ve/bin/python manage.py test
+RUN mkdir -p /var/www/rolf/rolf \
+&& mkdir -p /var/tmp/rolf/checkouts \
+&& mkdir -p /var/tmp/rolf/scripts \
+&& VE=/ve/ MANAGE="/ve/bin/python manage.py" NODE_MODULES=/node/node_modules/ make
 EXPOSE 8000
 ADD docker-run.sh /run.sh
 ENV APP rolf


### PR DESCRIPTION
Since Rolf is deployed as a docker app, I thought it was worth polishing
up its setup a bit.

I'm doing a couple tricks in here to improve things:

* by touching some sentinal files, and installing `build-essential`, it
  can now use a plain `make` to run tests inside the docker image. That
  includes flake8, jshint, jscs, etc. This should help a lot since means
  that things like `MAX_COMPLEXITY`, `JS_FILES`, etc set within the
  `Makefile` will actually be respected and we don't have to duplicate
  those settings between the `Makefile` and `Dockerfile`.

* Rolf doesn't currently use anything like webpack that builds bundles
  that will actually be used when running in production, but if it did,
  those could now be baked into the image at build time. As that becomes
  a more important part of our build process, this will become more
  necessary for making nice docker images.

* since `package.json` typically changes less often than
  `requirements.txt`, I put the `npm install` step first, before
  anything else is copied into the image. This should allow docker to
  re-use the layer with the npm libs already installed as often as
  possible, keeping builds as fast as possible.